### PR TITLE
generate type definition file to support 'export default' way

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,10 @@ function emitFile(
                     `export * from './${path.relative(
                       path.relative(cwd, modulePath),
                       o.name.replace('.d.ts', '')
-                    )}'`
+                    )}';\nexport { default } from './${path.relative(
+                      path.relative(cwd, modulePath),
+                      o.name.replace('.d.ts', '')
+                    )}';`
                   )
                 }
               }


### PR DESCRIPTION
Hi, First of all, thank you very much for providing `dts-loader`. 
I have a problem when using it, that is using [React.lazy](https://reactjs.org/docs/code-splitting.html#reactlazy) to import which another app exposes components. The error is as follows：
![image](https://user-images.githubusercontent.com/15188182/124588426-5d2d4380-de8b-11eb-9b3d-4286be4907cf.png)
Because of [React.lazy](https://reactjs.org/docs/code-splitting.html#reactlazy) takes a function that must call a dynamic import(). This must return a Promise which resolves to a module with a **default export** containing a React component. 
So I have made some additions to the source code