### PR TITLE
fix: broken paths in windows

### DIFF
--- a/packages/dts-loader/src/index.ts
+++ b/packages/dts-loader/src/index.ts
@@ -129,7 +129,7 @@ function emitFile(
                     const relativePathToOutput = path.relative(
                       path.dirname(dtsEntryPath),
                       o.name.replace('.d.ts', '')
-                    )
+                    ).replace(/\\/g, '/')
 
                     fs.ensureFileSync(dtsEntryPath)
                     fs.writeFileSync(


### PR DESCRIPTION
Adjusted fs backslashes resolved by 'path' with forward slashes to avoid broken module paths in Windows

---------------

I noticed that when running on Windows, the module paths were broken as they are unintentionally resolved by path (or so I assume, since we just want the relative path and not necessarily the path resolving), resulting in a path with backslashes where there should be forward slashes.

Example output for one of my files when ran under macOS:
```ts
export * from './dts/stores/Store';
export { default } from './dts/stores/Store';
```

Same file but generated in Windows:
```ts
export * from './dts\stores\Store';
export { default } from './dts\stores\Store';
```

Even if the paths did resolve properly (by escaping the backslashes), it'd end up creating different files depending on which OS is running, which would be unusable for my team, so I figured just replacing the backslashes with forward slashes will produce consistent results across the board. The call to path.relative is still needed to get the relative path, but it shouldn't be resolved, maybe there's a more elegant way to go about that.

